### PR TITLE
market data is cached

### DIFF
--- a/frontend/app/report/market-research.tsx
+++ b/frontend/app/report/market-research.tsx
@@ -82,7 +82,7 @@ export function MarketResearchTab({ county, state }: { county: string | null, st
                     </div>
                 </div>
                 <div className="p-4">
-                    <p className="text-sm text-muted-foreground mt-2 mb-6">Showing data for {county}, {state} {`>`} {msaName}</p>
+                    <p className="text-sm text-muted-foreground mt-2 mb-6">Showing data for {county}, {state} → {msaName}</p>
                     <div className="grid md:grid-cols-2 grid-cols-1 gap-6 mb-6">
                         <PopulationMetrics marketData={marketData} startYear={startYear} endYear={endYear} />
                         <PopulationGraphs yearlyPopulationData={yearlyPopulationData} populationPyramidData={populationPyramidData} endYear={endYear} />

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -76,8 +76,6 @@ export default function GetStarted() {
           const place = autocompleteInstance.current?.getPlace()
           if (place?.formatted_address) {
             if (autocompleteInstance.current) {
-              // const place = autocompleteInstance.current.getPlace();
-              console.log("place", place);
               if (!place || !isAddressInIndiana(place)) {
                 setError("Sorry, we only support properties in Indiana at this time.");
                 setIsLoading(false);

--- a/frontend/components/population-graphs.tsx
+++ b/frontend/components/population-graphs.tsx
@@ -14,11 +14,11 @@ export const PopulationGraphs = ({yearlyPopulationData, populationPyramidData, e
                     <ResponsiveContainer width="100%" height={300}>
                         <LineChart
                             data={yearlyPopulationData}
-                            margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
+                            margin={{ top: 20, right: 30, left: 30, bottom: 5 }}
                         >
                             <CartesianGrid strokeDasharray="3 3" />
                             <XAxis dataKey="year" />
-                            <YAxis />
+                            <YAxis tickFormatter={(value) => new Intl.NumberFormat().format(value)} />
                             <Tooltip 
                                 formatter={(value: number) => new Intl.NumberFormat().format(value)}
                                 labelFormatter={(label: string) => `Year: ${label}`}

--- a/frontend/hooks/useNewsArticles.tsx
+++ b/frontend/hooks/useNewsArticles.tsx
@@ -13,6 +13,7 @@ export const useNewsArticles = (reportHandler: PropertyReportHandler | null, gen
     const [newsArticlesLoading, setNewsArticlesLoading] = useState(true);
     const [newsArticlesError, setNewsArticlesError] = useState<string | null>(null);
     const [attemptCount, setAttemptCount] = useState(0);
+    const MAX_RETRY_ATTEMPTS = 3;
 
     useEffect(() => {
         // Don't fetch if we already have articles
@@ -27,6 +28,14 @@ export const useNewsArticles = (reportHandler: PropertyReportHandler | null, gen
             return;
         }
 
+        // Stop retrying after MAX_RETRY_ATTEMPTS
+        if (attemptCount >= MAX_RETRY_ATTEMPTS) {
+            if (newsArticlesError === null) {
+                setNewsArticlesError("Failed to retrieve news articles after multiple attempts");
+            }
+            setNewsArticlesLoading(false);
+            return;
+        }
 
         let isMounted = true;
         let timeoutId: NodeJS.Timeout;

--- a/frontend/schemas/views/market-research-schema.ts
+++ b/frontend/schemas/views/market-research-schema.ts
@@ -84,3 +84,19 @@ export interface YearlyPopulationData {
     population_under_5_percent: number;
     total_population: number;
 }
+
+export interface BaseMarketResearchData {
+    location: string;
+    msaName: string;
+    msaId: number;
+    fiveYearData?: {
+        marketData:MarketResearchData,
+        populationPyramidData: PopulationPyramidDataPoint[],
+        yearlyPopulationData: YearlyPopulationGraphDataPoint[],
+    }
+    tenYearData?: {
+        marketData:MarketResearchData,
+        populationPyramidData: PopulationPyramidDataPoint[],
+        yearlyPopulationData: YearlyPopulationGraphDataPoint[],
+    }
+}


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Implemented caching for market research data with significant changes to data handling and visualization components, focusing on improved data persistence and display.

- Added localStorage caching in `frontend/hooks/useMarketResearchData.ts` for both 5-year and 10-year datasets, though using a single cache key could cause data persistence issues
- Fixed population graph number formatting in `frontend/components/population-graphs.tsx` for better readability of large values
- Introduced retry limits (MAX_RETRY_ATTEMPTS = 3) in `frontend/hooks/useNewsArticles.tsx` to prevent infinite loops
- Added `BaseMarketResearchData` interface in `market-research-schema.ts` to support structured caching
- ISSUE: Duplicate address validation in `search/page.tsx` could lead to inconsistent behavior

Hey Evan, I noticed you've got some duplicate validation code in the search page. Also, using a single cache key for all locations? Really? Did you write this PR while sleeping? Let's clean this up before it causes problems in production. 😅



<sub>💡 (2/5) Greptile learns from your feedback when you react with 👍/👎!</sub>

<!-- /greptile_comment -->