### PR TITLE
Market research updates

### DIFF
--- a/frontend/app/report/market-research.tsx
+++ b/frontend/app/report/market-research.tsx
@@ -82,7 +82,7 @@ export function MarketResearchTab({ county, state }: { county: string | null, st
                     </div>
                 </div>
                 <div className="p-4">
-                    <p className="text-sm text-muted-foreground mt-2 mb-6">Showing data for {county}, {state} {`>`} {msaName}</p>
+                    <p className="text-sm text-muted-foreground mt-2 mb-6">Showing data for {county}, {state} → {msaName}</p>
                     <div className="grid md:grid-cols-2 grid-cols-1 gap-6 mb-6">
                         <PopulationMetrics marketData={marketData} startYear={startYear} endYear={endYear} />
                         <PopulationGraphs yearlyPopulationData={yearlyPopulationData} populationPyramidData={populationPyramidData} endYear={endYear} />

--- a/frontend/app/report/market-research.tsx
+++ b/frontend/app/report/market-research.tsx
@@ -7,8 +7,9 @@ import { PopulationGraphs } from "@/components/population-graphs";
 import { AlertCircle, Users2 } from "lucide-react";
 import "@/styles/report.css";
 import { useMarketResearchData } from "@/hooks/useMarketResearchData";
+import { PropertyReportHandler } from "@/lib/report-handler";
 
-export function MarketResearchTab({ county, state }: { county: string | null, state: string | null }) {
+export function MarketResearchTab({ reportHandler, county, state }: { reportHandler: PropertyReportHandler, county: string | null, state: string | null }) {
   const [startYear, setStartYear] = useState(2013);
   const [endYear, setEndYear] = useState(2023);
   const [selectedYearRange, setSelectedYearRange] = useState<string>("10-year-data");
@@ -20,7 +21,7 @@ export function MarketResearchTab({ county, state }: { county: string | null, st
     msaName, 
     loading, 
     error 
-  } = useMarketResearchData(county, state, startYear, endYear);
+  } = useMarketResearchData(reportHandler, county, state, startYear, endYear);
   
   const handleFiveYears = () => {
     setStartYear(2018);

--- a/frontend/app/report/page.tsx
+++ b/frontend/app/report/page.tsx
@@ -276,10 +276,10 @@ export default function PropertyAnalysisDashboard() {
             <div className="mb-8">
               <h2 className="text-2xl font-semibold mb-4">Market Research</h2>
               <p className="text-muted-foreground">
-                Market research and analysis of the area.
+                Market research and analysis of the area, compiled from US Census data and Esri.
               </p>
             </div>
-            <MarketResearchTab county={county} state={state} />
+            <MarketResearchTab reportHandler={reportHandler!} county={county} state={state} />
           </TabsContent>
 
           <TabsContent value="news" className="m-0" data-section="news">

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -76,8 +76,6 @@ export default function GetStarted() {
           const place = autocompleteInstance.current?.getPlace()
           if (place?.formatted_address) {
             if (autocompleteInstance.current) {
-              // const place = autocompleteInstance.current.getPlace();
-              console.log("place", place);
               if (!place || !isAddressInIndiana(place)) {
                 setError("Sorry, we only support properties in Indiana at this time.");
                 setIsLoading(false);

--- a/frontend/components/population-graphs.tsx
+++ b/frontend/components/population-graphs.tsx
@@ -14,11 +14,11 @@ export const PopulationGraphs = ({yearlyPopulationData, populationPyramidData, e
                     <ResponsiveContainer width="100%" height={300}>
                         <LineChart
                             data={yearlyPopulationData}
-                            margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
+                            margin={{ top: 20, right: 30, left: 30, bottom: 5 }}
                         >
                             <CartesianGrid strokeDasharray="3 3" />
                             <XAxis dataKey="year" />
-                            <YAxis />
+                            <YAxis tickFormatter={(value) => new Intl.NumberFormat().format(value)} />
                             <Tooltip 
                                 formatter={(value: number) => new Intl.NumberFormat().format(value)}
                                 labelFormatter={(label: string) => `Year: ${label}`}

--- a/frontend/components/population-graphs.tsx
+++ b/frontend/components/population-graphs.tsx
@@ -3,9 +3,9 @@
 import { Loader2 } from "lucide-react";
 import "@/styles/report.css";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, BarChart, Bar, ReferenceLine } from 'recharts';
-import { YearlyPopulationGraphDataPoint, PopulationPyramidDataPoint } from "@/schemas/views/market-research-schema";
+import { YearlyPopulationGraphDataPointSchema, PopulationPyramidDataPointSchema } from "@/schemas/views/market-research-schema";
 
-export const PopulationGraphs = ({yearlyPopulationData, populationPyramidData, endYear}: {yearlyPopulationData: YearlyPopulationGraphDataPoint[], populationPyramidData: PopulationPyramidDataPoint[], endYear: number}) => {
+export const PopulationGraphs = ({yearlyPopulationData, populationPyramidData, endYear}: {yearlyPopulationData: YearlyPopulationGraphDataPointSchema[], populationPyramidData: PopulationPyramidDataPointSchema[], endYear: number}) => {
     return (
         <div className="flex flex-col gap-6">
             <div className="market-data-section">

--- a/frontend/components/population-metrics.tsx
+++ b/frontend/components/population-metrics.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { MarketResearchData } from "@/schemas/views/market-research-schema";
+import { MarketResearchDataSchema } from "@/schemas/views/market-research-schema";
 
 const formatNumber = (num: number | null | undefined) => {
     if (num === null || num === undefined) return 'N/A';
@@ -12,7 +12,7 @@ const formatPercent = (num: number | null | undefined) => {
     return `${num}%`;
 };
 
-export const PopulationMetrics = ({marketData, startYear, endYear}: {marketData: MarketResearchData, startYear: number, endYear: number}) => {
+export const PopulationMetrics = ({marketData, startYear, endYear}: {marketData: MarketResearchDataSchema, startYear: number, endYear: number}) => {
     return (
         <div className="flex flex-col gap-6">
             <div className="market-data-section">

--- a/frontend/hooks/useNewsArticles.tsx
+++ b/frontend/hooks/useNewsArticles.tsx
@@ -13,6 +13,7 @@ export const useNewsArticles = (reportHandler: PropertyReportHandler | null, gen
     const [newsArticlesLoading, setNewsArticlesLoading] = useState(true);
     const [newsArticlesError, setNewsArticlesError] = useState<string | null>(null);
     const [attemptCount, setAttemptCount] = useState(0);
+    const MAX_RETRY_ATTEMPTS = 3;
 
     useEffect(() => {
         // Don't fetch if we already have articles
@@ -27,6 +28,14 @@ export const useNewsArticles = (reportHandler: PropertyReportHandler | null, gen
             return;
         }
 
+        // Stop retrying after MAX_RETRY_ATTEMPTS
+        if (attemptCount >= MAX_RETRY_ATTEMPTS) {
+            if (newsArticlesError === null) {
+                setNewsArticlesError("Failed to retrieve news articles after multiple attempts");
+            }
+            setNewsArticlesLoading(false);
+            return;
+        }
 
         let isMounted = true;
         let timeoutId: NodeJS.Timeout;

--- a/frontend/lib/report-handler.ts
+++ b/frontend/lib/report-handler.ts
@@ -168,6 +168,8 @@ export class PropertyReportHandler {
     return {
       propertyUrl: this.propertyUrl,
       generalInfo: this.generalInfo,
+      developmentInfo: this.developmentInfo,
+      marketResearch: this.marketResearch,
       status: this.status,
       errors: this.errors,
       createdAt: this.createdAt.toISOString(),
@@ -410,6 +412,8 @@ export interface ReportError {
 export interface PropertyReportJSON {
   propertyUrl: string | null;
   generalInfo: GeneralPropertyInfo | null;
+  developmentInfo: DevelopmentInfo | null;
+  marketResearch: MarketResearch | null;
   status: ReportStatus;
   errors: ReportError[];
   createdAt: string;

--- a/frontend/lib/report-handler.ts
+++ b/frontend/lib/report-handler.ts
@@ -312,10 +312,7 @@ export class PropertyReportHandler {
     existing: MarketResearch,
     updates: Partial<MarketResearch>
   ): MarketResearch {
-    return this.deepMerge(
-      existing as unknown as Record<string, unknown>,
-      updates as unknown as Record<string, unknown>
-    ) as unknown as MarketResearch;
+    return this.deepMerge(existing, updates) as MarketResearch;
   }
 
   private deepMerge(

--- a/frontend/lib/report-handler.ts
+++ b/frontend/lib/report-handler.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { GeneralPropertyInfo, DataPoint, GeneralPropertyInfoSchema } from "../schemas/views/general-property-info-schema";
 import { DevelopmentInfo, DevelopmentInfoSchema } from "../schemas/views/development-info-schema";
+import { MarketResearch, MarketResearchSchema } from "../schemas/views/market-research-schema";
 /**
  * PropertyReportHandler class for managing and processing real estate property reports.
  * It handles data collection, validation, and formatting for property analysis.
@@ -8,6 +9,7 @@ import { DevelopmentInfo, DevelopmentInfoSchema } from "../schemas/views/develop
 export class PropertyReportHandler {
   private generalInfo: GeneralPropertyInfo | null = null;
   private developmentInfo: DevelopmentInfo | null = null;
+  private marketResearch: MarketResearch | null = null;
   private rawData: Record<string, unknown> = {};
   private propertyUrl: string | null = null;
   private createdAt: Date = new Date();
@@ -74,6 +76,31 @@ export class PropertyReportHandler {
   getDevelopmentInfo(): DevelopmentInfo | null {
     return this.developmentInfo;
   } 
+
+  setMarketResearch(data: Partial<MarketResearch>): void {
+    try {
+      const mergedData = this.marketResearch
+        ? this.mergeMarketResearch(this.marketResearch, data)
+        : data;
+      this.rawData = { ...this.rawData, ...data };
+      try {
+        this.marketResearch = PropertyReportHandler.validateMarketResearch(mergedData as MarketResearch);
+      } catch (error) {
+        console.log("validation error", error);
+      }
+      this.updatedAt = new Date();
+      this.status = "updated";
+    } catch (error) {
+      this.handleError(
+        "validation_error",
+        `Failed to set market research: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  getMarketResearch(): MarketResearch | null {
+    return this.marketResearch;
+  }
 
   updateDataPoint(
     path: string,
@@ -256,6 +283,17 @@ export class PropertyReportHandler {
     }
   }
 
+  public static validateMarketResearch(data: MarketResearch): MarketResearch {
+    try {
+      return MarketResearchSchema.parse(data);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new Error(`Validation error: ${JSON.stringify(error.errors)}`); 
+      }
+      throw error;
+    }
+  }
+
   private mergeGeneralInfo(
     existing: GeneralPropertyInfo,
     updates: Partial<GeneralPropertyInfo>
@@ -268,6 +306,16 @@ export class PropertyReportHandler {
     updates: Partial<DevelopmentInfo>
   ): DevelopmentInfo {
     return this.deepMerge(existing, updates) as DevelopmentInfo;
+  }
+
+  private mergeMarketResearch(
+    existing: MarketResearch,
+    updates: Partial<MarketResearch>
+  ): MarketResearch {
+    return this.deepMerge(
+      existing as unknown as Record<string, unknown>,
+      updates as unknown as Record<string, unknown>
+    ) as unknown as MarketResearch;
   }
 
   private deepMerge(

--- a/frontend/schemas/views/market-research-schema.ts
+++ b/frontend/schemas/views/market-research-schema.ts
@@ -84,3 +84,19 @@ export interface YearlyPopulationData {
     population_under_5_percent: number;
     total_population: number;
 }
+
+export interface BaseMarketResearchData {
+    location: string;
+    msaName: string;
+    msaId: number;
+    fiveYearData?: {
+        marketData:MarketResearchData,
+        populationPyramidData: PopulationPyramidDataPoint[],
+        yearlyPopulationData: YearlyPopulationGraphDataPoint[],
+    }
+    tenYearData?: {
+        marketData:MarketResearchData,
+        populationPyramidData: PopulationPyramidDataPoint[],
+        yearlyPopulationData: YearlyPopulationGraphDataPoint[],
+    }
+}

--- a/frontend/schemas/views/market-research-schema.ts
+++ b/frontend/schemas/views/market-research-schema.ts
@@ -1,102 +1,126 @@
-export interface PopulationPyramidDataPoint {
-    ageGroup: string;
-    percentage: number;
-}
+import { z } from 'zod';
 
-export interface YearlyPopulationGraphDataPoint {
-    year: number;
-    population: number;
-}
+export const populationPyramidDataPointSchema = z.object({
+  ageGroup: z.string(),
+  percentage: z.number(),
+});
 
-export interface MarketResearchData {
+export const yearlyPopulationGraphDataPointSchema = z.object({
+  year: z.number(),
+  population: z.number(),
+});
+
+export const marketResearchDataSchema = z.object({
   // Population growth
-  pop_end: number;
-  pop_start: number;
-  percent_population_change: number | null;
+  pop_end: z.number(),
+  pop_start: z.number(),
+  percent_population_change: z.number().nullable(),
   
   // Gender distribution
-  male_percent_end: number;
-  female_percent_end: number;
-  male_moe_percent_end: number;
-  female_moe_percent_end: number;
+  male_percent_end: z.number(),
+  female_percent_end: z.number(),
+  male_moe_percent_end: z.number(),
+  female_moe_percent_end: z.number(),
   
   // Age demographics
-  median_age_end: number;
-  median_age_start: number;
-  median_age_change: number;
+  median_age_end: z.number(),
+  median_age_start: z.number(),
+  median_age_change: z.number(),
   
   // Youth vs Aging
-  youth_percent_2023: number;
-  aging_percent_2023: number;
+  youth_percent_2023: z.number(),
+  aging_percent_2023: z.number(),
   
   // Prime working age
-  working_age_percent_2023: number;
+  working_age_percent_2023: z.number(),
   
   // Age dependency ratio
-  age_dependency_ratio_2023: number;
+  age_dependency_ratio_2023: z.number(),
   
   // Population Change by Age Bracket
-  pop_change_25_to_34_percent: number | null;
+  pop_change_25_to_34_percent: z.number().nullable(),
   
   // Generations
-  boomer_percent_2023: number;
-  millennial_percent_2023: number;
-}
+  boomer_percent_2023: z.number(),
+  millennial_percent_2023: z.number(),
+});
 
-export interface YearlyPopulationData {
-    female_population: number;
-    female_population_moe: number;
-    female_population_moe_percent: number;
-    female_population_percent: number;
-    id: number;
-    male_population: number;
-    male_population_moe: number;
-    male_population_moe_percent: number;
-    male_population_percent: number;
-    median_age: number;
-    median_age_moe: number;
-    name: string;
-    population_5_to_9: number;
-    population_5_to_9_percent: number;
-    population_10_to_14: number;
-    population_10_to_14_percent: number;
-    population_15_to_19: number;
-    population_15_to_19_percent: number;
-    population_20_to_24: number;
-    population_20_to_24_percent: number;
-    population_25_to_34: number;
-    population_25_to_34_percent: number;
-    population_35_to_44: number;
-    population_35_to_44_percent: number;
-    population_45_to_54: number;
-    population_45_to_54_percent: number;
-    population_55_to_59: number;
-    population_55_to_59_percent: number;
-    population_60_to_64: number;
-    population_60_to_64_percent: number;
-    population_65_to_74: number;
-    population_65_to_74_percent: number;
-    population_75_to_84: number;
-    population_75_to_84_percent: number;
-    population_85_older: number;
-    population_85_older_percent: number;
-    population_under_5: number;
-    population_under_5_percent: number;
-    total_population: number;
-}
+export const yearlyPopulationDataSchema = z.object({
+  female_population: z.number(),
+  female_population_moe: z.number(),
+  female_population_moe_percent: z.number(),
+  female_population_percent: z.number(),
+  id: z.number(),
+  male_population: z.number(),
+  male_population_moe: z.number(),
+  male_population_moe_percent: z.number(),
+  male_population_percent: z.number(),
+  median_age: z.number(),
+  median_age_moe: z.number(),
+  name: z.string(),
+  population_5_to_9: z.number(),
+  population_5_to_9_percent: z.number(),
+  population_10_to_14: z.number(),
+  population_10_to_14_percent: z.number(),
+  population_15_to_19: z.number(),
+  population_15_to_19_percent: z.number(),
+  population_20_to_24: z.number(),
+  population_20_to_24_percent: z.number(),
+  population_25_to_34: z.number(),
+  population_25_to_34_percent: z.number(),
+  population_35_to_44: z.number(),
+  population_35_to_44_percent: z.number(),
+  population_45_to_54: z.number(),
+  population_45_to_54_percent: z.number(),
+  population_55_to_59: z.number(),
+  population_55_to_59_percent: z.number(),
+  population_60_to_64: z.number(),
+  population_60_to_64_percent: z.number(),
+  population_65_to_74: z.number(),
+  population_65_to_74_percent: z.number(),
+  population_75_to_84: z.number(),
+  population_75_to_84_percent: z.number(),
+  population_85_older: z.number(),
+  population_85_older_percent: z.number(),
+  population_under_5: z.number(),
+  population_under_5_percent: z.number(),
+  total_population: z.number(),
+});
 
-export interface BaseMarketResearchData {
+export interface MarketResearch {
     location: string;
     msaName: string;
     msaId: number;
-    fiveYearData?: {
-        marketData:MarketResearchData,
-        populationPyramidData: PopulationPyramidDataPoint[],
-        yearlyPopulationData: YearlyPopulationGraphDataPoint[],
+    fiveYearData: {
+        marketData:MarketResearchDataSchema,
+        populationPyramidData: PopulationPyramidDataPointSchema[],
+        yearlyPopulationData: YearlyPopulationGraphDataPointSchema[],
     }
-    tenYearData?: {
-        marketData:MarketResearchData,
-        populationPyramidData: PopulationPyramidDataPoint[],
-        yearlyPopulationData: YearlyPopulationGraphDataPoint[],
+    tenYearData: {
+        marketData:MarketResearchDataSchema,
+        populationPyramidData: PopulationPyramidDataPointSchema[],
+        yearlyPopulationData: YearlyPopulationGraphDataPointSchema[],
     }
 }
+
+export const MarketResearchSchema = z.object({
+  "location": z.string(),
+  "msaName": z.string(),
+  "msaId": z.number(),
+  "fiveYearData": z.object({
+    "marketData": marketResearchDataSchema,
+    "populationPyramidData": z.array(populationPyramidDataPointSchema),
+    "yearlyPopulationData": z.array(yearlyPopulationGraphDataPointSchema),
+  }),
+  "tenYearData": z.object({
+    "marketData": marketResearchDataSchema,
+    "populationPyramidData": z.array(populationPyramidDataPointSchema),
+    "yearlyPopulationData": z.array(yearlyPopulationGraphDataPointSchema),
+  }),
+});
+
+// export type MarketResearchSchema = z.infer<typeof marketResearchSchema>;
+export type MarketResearchDataSchema = z.infer<typeof marketResearchDataSchema>;
+export type PopulationPyramidDataPointSchema = z.infer<typeof populationPyramidDataPointSchema>;
+export type YearlyPopulationGraphDataPointSchema = z.infer<typeof yearlyPopulationGraphDataPointSchema>;
+export type YearlyPopulationDataSchema = z.infer<typeof yearlyPopulationDataSchema>;

--- a/frontend/schemas/views/market-research-schema.ts
+++ b/frontend/schemas/views/market-research-schema.ts
@@ -87,39 +87,59 @@ export const yearlyPopulationDataSchema = z.object({
   total_population: z.number(),
 });
 
-export interface MarketResearch {
-    location: string;
-    msaName: string;
-    msaId: number;
-    fiveYearData: {
-        marketData:MarketResearchDataSchema,
-        populationPyramidData: PopulationPyramidDataPointSchema[],
-        yearlyPopulationData: YearlyPopulationGraphDataPointSchema[],
-    }
-    tenYearData: {
-        marketData:MarketResearchDataSchema,
-        populationPyramidData: PopulationPyramidDataPointSchema[],
-        yearlyPopulationData: YearlyPopulationGraphDataPointSchema[],
-    }
-}
-
 export const MarketResearchSchema = z.object({
   "location": z.string(),
   "msaName": z.string(),
   "msaId": z.number(),
   "fiveYearData": z.object({
-    "marketData": marketResearchDataSchema,
+    "marketData": z.object({
+            "pop_end": z.number(),
+            "pop_start": z.number(),
+            "percent_population_change": z.number().nullable(),
+            "male_percent_end": z.number(),
+            "female_percent_end": z.number(),
+            "male_moe_percent_end": z.number(),
+            "female_moe_percent_end": z.number(),
+            "median_age_end": z.number(),
+            "median_age_start": z.number(),
+            "median_age_change": z.number(),
+            "youth_percent_2023": z.number(),
+            "aging_percent_2023": z.number(),
+            "working_age_percent_2023": z.number(),
+            "age_dependency_ratio_2023": z.number(),
+            "pop_change_25_to_34_percent": z.number().nullable(),
+            "boomer_percent_2023": z.number(),
+            "millennial_percent_2023": z.number(),
+        }),
     "populationPyramidData": z.array(populationPyramidDataPointSchema),
     "yearlyPopulationData": z.array(yearlyPopulationGraphDataPointSchema),
   }),
   "tenYearData": z.object({
-    "marketData": marketResearchDataSchema,
+    "marketData": z.object({
+            "pop_end": z.number(),
+            "pop_start": z.number(),
+            "percent_population_change": z.number().nullable(),
+            "male_percent_end": z.number(),
+            "female_percent_end": z.number(),
+            "male_moe_percent_end": z.number(),
+            "female_moe_percent_end": z.number(),
+            "median_age_end": z.number(),
+            "median_age_start": z.number(),
+            "median_age_change": z.number(),
+            "youth_percent_2023": z.number(),
+            "aging_percent_2023": z.number(),
+            "working_age_percent_2023": z.number(),
+            "age_dependency_ratio_2023": z.number(),
+            "pop_change_25_to_34_percent": z.number().nullable(),
+            "boomer_percent_2023": z.number(),
+            "millennial_percent_2023": z.number(),
+        }),
     "populationPyramidData": z.array(populationPyramidDataPointSchema),
     "yearlyPopulationData": z.array(yearlyPopulationGraphDataPointSchema),
   }),
 });
 
-// export type MarketResearchSchema = z.infer<typeof marketResearchSchema>;
+export type MarketResearch = z.infer<typeof MarketResearchSchema>;
 export type MarketResearchDataSchema = z.infer<typeof marketResearchDataSchema>;
 export type PopulationPyramidDataPointSchema = z.infer<typeof populationPyramidDataPointSchema>;
 export type YearlyPopulationGraphDataPointSchema = z.infer<typeof yearlyPopulationGraphDataPointSchema>;

--- a/frontend/schemas/views/report-schema.ts
+++ b/frontend/schemas/views/report-schema.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 import { DevelopmentInfoSchema } from "@/schemas/views/development-info-schema";
 import { GeneralPropertyInfoSchema } from "@/schemas/views/general-property-info-schema";
+import { MarketResearchSchema } from "@/schemas/views/market-research-schema";
 
 export const ReportSchema = z.object({
   generalPropertyInfo: GeneralPropertyInfoSchema,
   developmentInfo: DevelopmentInfoSchema,
+  marketResearch: MarketResearchSchema,
 });
 
 export type Report = z.infer<typeof ReportSchema>;


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR implements comprehensive market research functionality across the application, converting TypeScript interfaces to Zod schemas and integrating PropertyReportHandler for centralized data management.

- Added MarketResearchSchema to ReportSchema with Zod validation for both 5-year and 10-year datasets in `/frontend/schemas/views/market-research-schema.ts`
- Integrated PropertyReportHandler for market research data management with caching in `/frontend/hooks/useMarketResearchData.ts`
- Added retry logic with 3-attempt limit for news article fetching in `/frontend/hooks/useNewsArticles.tsx`
- Updated population graphs with improved number formatting and margin adjustments in `/frontend/components/population-graphs.tsx`
- Hardcoded '2023' in field names and schema duplication between fiveYearData/tenYearData could cause maintenance issues

The changes improve data validation and management but introduce potential technical debt around schema maintenance and year handling. Consider implementing dynamic year references and reducing schema duplication.



<sub>💡 (4/5) You can add custom instructions or style guidelines for the bot [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->