### PR TITLE
employment by industry and housing info

### DIFF
--- a/frontend/app/report/market-research.tsx
+++ b/frontend/app/report/market-research.tsx
@@ -4,13 +4,16 @@ import { useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { PopulationMetrics } from "@/components/population-metrics";
 import { PopulationGraphs } from "@/components/population-graphs";
-import { AlertCircle, Users2 } from "lucide-react";
+import { HousingMetrics } from "@/components/housing-metrics";
+import { AlertCircle, Users2, House, HardHat } from "lucide-react";
 import "@/styles/report.css";
 import { useMarketResearchData } from "@/hooks/useMarketResearchData";
 import { PropertyReportHandler } from "@/lib/report-handler";
+import { IndustryTable } from "@/components/industry-table";
+import { IndustryGraph } from "@/components/industry-graph";
 
 export function MarketResearchTab({ reportHandler, county, state }: { reportHandler: PropertyReportHandler, county: string | null, state: string | null }) {
-  const [startYear, setStartYear] = useState(2013);
+  const [startYear, setStartYear] = useState(2014);
   const [endYear, setEndYear] = useState(2023);
   const [selectedYearRange, setSelectedYearRange] = useState<string>("10-year-data");
   
@@ -18,19 +21,20 @@ export function MarketResearchTab({ reportHandler, county, state }: { reportHand
     marketData, 
     yearlyPopulationData, 
     populationPyramidData, 
+    esriData2024,
     msaName, 
     loading, 
     error 
   } = useMarketResearchData(reportHandler, county, state, startYear, endYear);
   
   const handleFiveYears = () => {
-    setStartYear(2018);
+    setStartYear(2019);
     setEndYear(2023);
     setSelectedYearRange("5-year-data");
   }
 
   const handleTenYears = () => {
-    setStartYear(2013);
+    setStartYear(2014);
     setEndYear(2023);
     setSelectedYearRange("10-year-data");
   }
@@ -70,7 +74,8 @@ export function MarketResearchTab({ reportHandler, county, state }: { reportHand
   return (
     <div className="container mx-auto max-w-7xl py-6">
       <div className="grid gap-8">
-        {marketData && (
+        {marketData && esriData2024 && (
+            <>
             <div className="rounded-lg border bg-card shadow-sm">
                 <div className="flex flex-row justify-between items-center gap-2 border-b md:col-span-2 col-span-1 px-6 py-4">
                     <div className="flex items-center gap-2">
@@ -85,11 +90,49 @@ export function MarketResearchTab({ reportHandler, county, state }: { reportHand
                 <div className="p-4">
                     <p className="text-sm text-muted-foreground mt-2 mb-6">Showing data for {county}, {state} → {msaName}</p>
                     <div className="grid md:grid-cols-2 grid-cols-1 gap-6 mb-6">
-                        <PopulationMetrics marketData={marketData} startYear={startYear} endYear={endYear} />
+                        <PopulationMetrics marketData={marketData} startYear={startYear} endYear={endYear} esriData2024={esriData2024} />
                         <PopulationGraphs yearlyPopulationData={yearlyPopulationData} populationPyramidData={populationPyramidData} endYear={endYear} />
                     </div>
                 </div>
             </div>
+            <div className="rounded-lg border bg-card shadow-sm">
+              <div className="flex flex-row justify-between items-center gap-2 border-b md:col-span-2 col-span-1 px-6 py-4">
+                  <div className="flex items-center gap-2">
+                      <House className="h-5 w-5" />
+                      <h2 className="text-lg font-semibold">Housing Information</h2>
+                  </div>
+                  <div className="flex items-center gap-2">
+                      2024 Esri Data
+                  </div>
+              </div>
+              <div className="p-4">
+                  <p className="text-sm text-muted-foreground mt-2 mb-6">Showing data for {county}, {state}</p>
+                  <div className="grid grid-cols-1 gap-6 mb-6">
+                      <HousingMetrics esriData2024={esriData2024} />
+                  </div>
+              </div>
+            </div>
+            <div className="rounded-lg border bg-card shadow-sm">
+              <div className="flex flex-row justify-between items-center gap-2 border-b md:col-span-2 col-span-1 px-6 py-4">
+                  <div className="flex items-center gap-2">
+                      <HardHat className="h-5 w-5" />
+                      <h2 className="text-lg font-semibold">Employment By Industry</h2>
+                  </div>
+                  <div className="flex items-center gap-2">
+                      2024 Esri Data
+                  </div>
+              </div>
+              <div className="p-4">
+                  <p className="text-sm text-muted-foreground mt-2 mb-6">Showing data for {county}, {state}</p>
+                  <div className="grid grid-cols-1 gap-6 mb-6">
+                      <IndustryTable esriData2024={esriData2024} />
+                      <div className="hidden sm:block">
+                          <IndustryGraph esriData2024={esriData2024} />
+                      </div>
+                  </div>
+              </div>
+            </div>
+            </>
           )}
       </div>
     </div>

--- a/frontend/app/report/page.tsx
+++ b/frontend/app/report/page.tsx
@@ -29,6 +29,7 @@ import { useNewsArticles } from "@/hooks/useNewsArticles";
 import { usePropertyImages } from "@/hooks/usePropertyImages";
 import { Button } from "@/components/ui/button";
 import SubmitEvaluationDialog from "@/components/submit-evaluation-dialog";
+import Link from "next/link";
 
 export default function PropertyAnalysisDashboard() {
   const [reportHandler, setReportHandler] = useState<PropertyReportHandler | null>(null);
@@ -42,7 +43,6 @@ export default function PropertyAnalysisDashboard() {
   const { developmentInfoLoading, developmentInfoError } = useDevelopmentInfo(reportHandler, generalPropertyInfoError);
   const { newsArticles, newsArticlesLoading, newsArticlesError } = useNewsArticles(reportHandler, generalPropertyInfoError);
   const { images, imagesLoading, imagesError } = usePropertyImages(propertyAddress);
-
   
   // First useEffect: Fetch general property information
   useEffect(() => {
@@ -276,7 +276,7 @@ export default function PropertyAnalysisDashboard() {
             <div className="mb-8">
               <h2 className="text-2xl font-semibold mb-4">Market Research</h2>
               <p className="text-muted-foreground">
-                Market research and analysis of the area, compiled from US Census data and Esri.
+                Market research and analysis of the area, compiled from US Census data and powered by <Link href="https://www.esri.com/en-us/home">Esri</Link>.
               </p>
             </div>
             <MarketResearchTab reportHandler={reportHandler!} county={county} state={state} />

--- a/frontend/components/housing-metrics.tsx
+++ b/frontend/components/housing-metrics.tsx
@@ -1,0 +1,50 @@
+"use client";
+import React from "react";
+import { EsriData2024Schema } from "@/schemas/views/market-research-schema";
+
+const formatNumber = (num: number | null | undefined) => {
+    if (num === null || num === undefined) return 'N/A';
+    return new Intl.NumberFormat().format(num);
+};
+
+export const HousingMetrics = ({esriData2024}: {esriData2024: EsriData2024Schema}) => {
+    return (
+        <div className="flex flex-col gap-6">
+            <div className="market-data-section">
+                <h3 className="text-lg font-semibold mb-2">Household Financials</h3>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                    <div className="stat-item">
+                        <p className="text-sm text-muted-foreground">Median Home Value</p>
+                        <p className="text-2xl font-bold">${formatNumber(esriData2024?.medianHomeValue)}</p>
+                    </div>
+                    <div className="stat-item">
+                        <p className="text-sm text-muted-foreground">Median Household Income</p>
+                        <p className="text-2xl font-bold">${formatNumber(esriData2024?.medianHouseholdIncome)}</p>
+                    </div>
+                    <div className="stat-item">
+                        <p className="text-sm text-muted-foreground">Average Household Income</p>
+                        <p className="text-2xl font-bold">${formatNumber(esriData2024?.averageHouseholdIncome)}</p>
+                    </div>
+                </div>
+            </div>
+
+            <div className="market-data-section">
+                <h3 className="text-lg font-semibold mb-2">Home Ownership</h3>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                    <div className="stat-item">
+                        <p className="text-sm text-muted-foreground">Owner Occupied Units</p>
+                        <p className="text-2xl font-bold">{formatNumber(esriData2024?.ownerOccupiedUnits)}</p>
+                    </div>
+                    <div className="stat-item">
+                        <p className="text-sm text-muted-foreground">Renter Occupied Units</p>
+                        <p className="text-2xl font-bold">{formatNumber(esriData2024?.renterOccupiedUnits)}</p>
+                    </div>
+                    <div className="stat-item">
+                        <p className="text-sm text-muted-foreground">Vacant Units</p>
+                        <p className="text-2xl font-bold">{formatNumber(esriData2024?.vacantUnits)}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/components/industry-graph.tsx
+++ b/frontend/components/industry-graph.tsx
@@ -1,0 +1,108 @@
+"use client";
+import React from "react";
+import { EsriData2024Schema } from "@/schemas/views/market-research-schema";
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from "recharts";
+
+const formatNumber = (num: number | null | undefined) => {
+    if (num === null || num === undefined) return 'N/A';
+    return new Intl.NumberFormat().format(num);
+};
+
+// Map of industry keys to display names
+const industryMap = {
+    agricultureForestryFishingHuntingPopulation: "Agriculture, Forestry, Fishing & Hunting",
+    miningQuarryingOilAndGasExtractionPopulation: "Mining, Quarrying, Oil & Gas Extraction",
+    constructionPopulation: "Construction",
+    manufacturingPopulation: "Manufacturing",
+    wholesaleTradePopulation: "Wholesale Trade",
+    retailTradePopulation: "Retail Trade",
+    transportationWarehousingPopulation: "Transportation & Warehousing",
+    utilitiesPopulation: "Utilities",
+    informationPopulation: "Information",
+    financeInsurancePopulation: "Finance & Insurance",
+    realEstateRentalLeasingPopulation: "Real Estate, Rental & Leasing",
+    professionalScientificTechnicalServicesPopulation: "Professional, Scientific & Technical Services",
+    managementOfCompaniesEnterprisesPopulation: "Management of Companies & Enterprises",
+    administrativeSupportWasteManagementServicesPopulation: "Administrative Support & Waste Management",
+    educationalServicesPopulation: "Educational Services",
+    healthCareSocialAssistancePopulation: "Healthcare & Social Assistance",
+    artsEntertainmentRecreationPopulation: "Arts, Entertainment & Recreation",
+    accommodationFoodServicesPopulation: "Accommodation & Food Services",
+    otherServicesPopulation: "Other Services",
+    publicAdministrationPopulation: "Public Administration",
+};
+
+export const IndustryGraph = ({esriData2024}: {esriData2024: EsriData2024Schema}) => {
+    if (!esriData2024 || !esriData2024.employmentByIndustry) return (
+        <div className="flex flex-col gap-6">
+            <div className="market-data-section">
+                <h3 className="text-lg font-semibold mb-2">Employment By Industry Pie Chart</h3>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                    <div className="stat-item">
+                        <p className="text-sm text-muted-foreground">This data is not available for this county.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+
+    // Create data for pie chart
+    const pieData = Object.entries(industryMap)
+        .map(([key, name]) => ({
+            name,
+            value: esriData2024.employmentByIndustry![key as keyof EsriData2024Schema] as number || 0
+        }))
+        .filter(item => item.value > 0)
+        .sort((a, b) => b.value - a.value);
+    
+    // Generate colors for the pie chart - more muted palette
+    const COLORS = [
+        '#4e79a7', '#59a14f', '#9c755f', '#f28e2b', '#76b7b2', 
+        '#edc948', '#b07aa1', '#ff9da7', '#6c5b7b', '#8cd17d',
+        '#86bcb6', '#a173a1', '#7a85d4', '#bab0ac', '#d37295',
+        '#99765f', '#5d887a', '#8e8a93', '#c7b42e', '#499894'
+    ];
+    
+    return (
+        <div className="flex flex-col gap-6">
+            <div className="market-data-section">
+                <h3 className="text-lg font-semibold mb-2">Employment By Industry Pie Chart</h3>
+                
+                {/* Pie Chart Section */}
+                <div className="mb-8">
+                    <ResponsiveContainer width="100%" height={600}>
+                        <PieChart>
+                            <Pie
+                                data={pieData}
+                                cx="50%"
+                                cy="50%"
+                                labelLine={false}
+                                outerRadius={150}
+                                fill="#8884d8"
+                                dataKey="value"
+                                label={({name, percent}) => {
+                                    // Only show labels for slices that are 5% or larger
+                                    return percent >= 0.05 ? `${name}: ${(percent * 100).toFixed(1)}%` : '';
+                                }}
+                            >
+                                {pieData.map((entry, index) => (
+                                    <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                                ))}
+                            </Pie>
+                            <Tooltip 
+                                formatter={(value) => formatNumber(value as number)}
+                                labelFormatter={(index) => pieData[index as number].name}
+                            />
+                            <Legend 
+                                layout="horizontal" 
+                                verticalAlign="bottom" 
+                                align="center"
+                                wrapperStyle={{ fontSize: '0.75rem' }} // Makes legend text smaller
+                            />
+                        </PieChart>
+                    </ResponsiveContainer>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/components/industry-table.tsx
+++ b/frontend/components/industry-table.tsx
@@ -1,0 +1,94 @@
+"use client";
+import React from "react";
+import { EsriData2024Schema } from "@/schemas/views/market-research-schema";
+
+const formatNumber = (num: number | null | undefined) => {
+    if (num === null || num === undefined) return 'N/A';
+    return new Intl.NumberFormat().format(num);
+};
+
+const formatPercentage = (value: number, total: number) => {
+    if (!total) return 'N/A';
+    return `${((value / total) * 100).toFixed(1)}%`;
+};
+
+// Map of industry keys to display names
+const industryMap = {
+    agricultureForestryFishingHuntingPopulation: "Agriculture, Forestry, Fishing & Hunting",
+    miningQuarryingOilAndGasExtractionPopulation: "Mining, Quarrying, Oil & Gas Extraction",
+    constructionPopulation: "Construction",
+    manufacturingPopulation: "Manufacturing",
+    wholesaleTradePopulation: "Wholesale Trade",
+    retailTradePopulation: "Retail Trade",
+    transportationWarehousingPopulation: "Transportation & Warehousing",
+    utilitiesPopulation: "Utilities",
+    informationPopulation: "Information",
+    financeInsurancePopulation: "Finance & Insurance",
+    realEstateRentalLeasingPopulation: "Real Estate, Rental & Leasing",
+    professionalScientificTechnicalServicesPopulation: "Professional, Scientific & Technical Services",
+    managementOfCompaniesEnterprisesPopulation: "Management of Companies & Enterprises",
+    administrativeSupportWasteManagementServicesPopulation: "Administrative Support & Waste Management",
+    educationalServicesPopulation: "Educational Services",
+    healthCareSocialAssistancePopulation: "Healthcare & Social Assistance",
+    artsEntertainmentRecreationPopulation: "Arts, Entertainment & Recreation",
+    accommodationFoodServicesPopulation: "Accommodation & Food Services",
+    otherServicesPopulation: "Other Services",
+    publicAdministrationPopulation: "Public Administration",
+};
+
+export const IndustryTable = ({esriData2024}: {esriData2024: EsriData2024Schema}) => {
+    const basePopulation = esriData2024?.employmentByIndustry?.industryBasePopulation || 0;
+
+    if (!esriData2024 || !esriData2024.employmentByIndustry) return (
+        <div className="flex flex-col gap-6">
+            <div className="market-data-section">
+                <h3 className="text-lg font-semibold mb-2">Employment By Industry Table</h3>
+                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                    <div className="stat-item">
+                        <p className="text-sm text-muted-foreground">This data is not available for this county.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+    
+    return (
+        <div className="flex flex-col gap-6">
+            <div className="market-data-section">
+                <h3 className="text-lg font-semibold mb-2">Employment By Industry Table</h3>
+                <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-gray-200">
+                        <thead className="bg-gray-50">
+                            <tr>
+                                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Industry
+                                </th>
+                                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Population
+                                </th>
+                                <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    % Population
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody className="bg-white divide-y divide-gray-200">
+                            {Object.entries(industryMap).map(([key, displayName]) => (
+                                <tr key={key}>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                        {displayName}
+                                    </td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                        {formatNumber(esriData2024.employmentByIndustry![key as keyof EsriData2024Schema] as number)}
+                                    </td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                        {formatPercentage(esriData2024.employmentByIndustry![key as keyof EsriData2024Schema] as number, basePopulation)}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/frontend/components/population-metrics.tsx
+++ b/frontend/components/population-metrics.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from "react";
-import { MarketResearchDataSchema } from "@/schemas/views/market-research-schema";
+import { MarketResearchDataSchema, EsriData2024Schema } from "@/schemas/views/market-research-schema";
 
 const formatNumber = (num: number | null | undefined) => {
     if (num === null || num === undefined) return 'N/A';
@@ -12,7 +12,7 @@ const formatPercent = (num: number | null | undefined) => {
     return `${num}%`;
 };
 
-export const PopulationMetrics = ({marketData, startYear, endYear}: {marketData: MarketResearchDataSchema, startYear: number, endYear: number}) => {
+export const PopulationMetrics = ({marketData, startYear, endYear, esriData2024}: {marketData: MarketResearchDataSchema, startYear: number, endYear: number, esriData2024: EsriData2024Schema}) => {
     return (
         <div className="flex flex-col gap-6">
             <div className="market-data-section">
@@ -89,6 +89,10 @@ export const PopulationMetrics = ({marketData, startYear, endYear}: {marketData:
                 <div className="stat-item">
                     <p className="text-sm text-muted-foreground">Millennial Share</p>
                     <p className="text-2xl font-bold">{formatPercent(marketData.millennial_percent_2023)}</p>
+                </div>
+                <div className="stat-item">
+                    <p className="text-sm text-muted-foreground">Unemployment Rate</p>
+                    <p className="text-2xl font-bold">{formatPercent(esriData2024?.unemploymentRate)}</p>
                 </div>
                 </div>
             </div>

--- a/frontend/hooks/useMarketResearchData.ts
+++ b/frontend/hooks/useMarketResearchData.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { createClient } from '@/utils/supabase/client';
-import { YearlyPopulationGraphDataPointSchema, PopulationPyramidDataPointSchema, YearlyPopulationDataSchema, MarketResearch, MarketResearchDataSchema } from "@/schemas/views/market-research-schema";
+import { YearlyPopulationGraphDataPointSchema, PopulationPyramidDataPointSchema, YearlyPopulationDataSchema, MarketResearch, MarketResearchDataSchema, EsriData2024Schema } from "@/schemas/views/market-research-schema";
 import { SupabaseClient } from '@supabase/supabase-js';
 import { PropertyReportHandler } from '@/lib/report-handler';
 
@@ -17,6 +17,7 @@ export function useMarketResearchData(
   const [msaName, setMsaName] = useState<string | null>(null);
   const [yearlyPopulationData, setYearlyPopulationData] = useState<YearlyPopulationGraphDataPointSchema[]>([]);
   const [populationPyramidData, setPopulationPyramidData] = useState<PopulationPyramidDataPointSchema[]>([]);
+  const [esriData2024, setEsriData2024] = useState<EsriData2024Schema | null>(null);
   
   useEffect(() => {
     async function fetchMarketData() {
@@ -25,7 +26,7 @@ export function useMarketResearchData(
       if (!reportHandler) return;
 
       if (reportHandler.getMarketResearch()) {
-        if (startYear === 2013) {
+        if (startYear === 2014) {
           setYearlyPopulationData(reportHandler.getMarketResearch()?.tenYearData?.yearlyPopulationData || []);
           setMarketData(reportHandler.getMarketResearch()?.tenYearData?.marketData || null);
           setPopulationPyramidData(reportHandler.getMarketResearch()?.tenYearData?.populationPyramidData || []);
@@ -34,6 +35,7 @@ export function useMarketResearchData(
           setMarketData(reportHandler.getMarketResearch()?.fiveYearData?.marketData || null);
           setPopulationPyramidData(reportHandler.getMarketResearch()?.fiveYearData?.populationPyramidData || []);
         }
+        setEsriData2024(reportHandler.getMarketResearch()?.esriData2024 || null);
         setLoading(false);
         return;
       }
@@ -45,7 +47,7 @@ export function useMarketResearchData(
       const cacheKey = "marketResearchData";
       
       // Determine if we need 5-year or 10-year data for display
-      const isDecadeView = startYear === 2013;
+      const isDecadeView = startYear === 2014;
       
       // Check if complete data exists in localStorage
       const cachedData = localStorage.getItem(cacheKey);
@@ -69,6 +71,8 @@ export function useMarketResearchData(
             throw new Error("Requested data range not in cache");
           }
 
+          setEsriData2024(parsedData.esriData2024);
+
           reportHandler.setMarketResearch(parsedData);
           
           setLoading(false);
@@ -85,6 +89,7 @@ export function useMarketResearchData(
         
         // Get MSA information
         const msaInfo = await fetchMsaInfo(supabase, location);
+        console.log(msaInfo);
         setMsaName(msaInfo.msaName);
         
         // Prepare container for complete cache data
@@ -92,6 +97,7 @@ export function useMarketResearchData(
           location: location,
           msaName: msaInfo.msaName,
           msaId: msaInfo.msaId,
+          fipsCode: msaInfo.fipsCode,
           fiveYearData: {
             marketData: {
               pop_end: 0,
@@ -138,10 +144,45 @@ export function useMarketResearchData(
             populationPyramidData: [],
             yearlyPopulationData: [],
           },
+          esriData2024: {
+            averageHouseholdIncome: -1,
+            employmentPopulation: -1,
+            medianHomeValue: -1,
+            medianHouseholdIncome: -1,
+            ownerOccupiedUnits: -1,
+            renterOccupiedUnits: -1,
+            unemploymentPopulation: -1,
+            vacantUnits: -1,
+            workingAgePopulation: -1,
+            unemploymentRate: -1,
+            employmentByIndustry: {
+              industryBasePopulation: -1,
+              agricultureForestryFishingHuntingPopulation: -1,
+              miningQuarryingOilAndGasExtractionPopulation: -1,
+              constructionPopulation: -1,
+              manufacturingPopulation: -1,
+              wholesaleTradePopulation: -1,
+              retailTradePopulation: -1,
+              transportationWarehousingPopulation: -1,
+              utilitiesPopulation: -1,
+              informationPopulation: -1,
+              financeInsurancePopulation: -1,
+              realEstateRentalLeasingPopulation: -1,
+              professionalScientificTechnicalServicesPopulation: -1,
+              managementOfCompaniesEnterprisesPopulation: -1,
+              administrativeSupportWasteManagementServicesPopulation: -1,
+              educationalServicesPopulation: -1,
+              healthCareSocialAssistancePopulation: -1,
+              artsEntertainmentRecreationPopulation: -1,
+              accommodationFoodServicesPopulation: -1,
+              otherServicesPopulation: -1,
+              publicAdministrationPopulation: -1,
+            }
+          }
         };
         
         // Fetch 10-year data (2013-2023)
-        const tenYearStart = 2013;
+        const tenYearStart = 2014;
         const tenYearEnd = 2023;
         const tenYearlyData = await fetchYearlyData(supabase, msaInfo.msaId, tenYearStart, tenYearEnd);
         
@@ -161,7 +202,7 @@ export function useMarketResearchData(
         };
         
         // Fetch 5-year data (2018-2023)
-        const fiveYearStart = 2018;
+        const fiveYearStart = 2019;
         const fiveYearlyData = tenYearlyData.filter(item => item.year >= fiveYearStart);
         
         // Fetch 5-year start and end detailed data
@@ -178,6 +219,42 @@ export function useMarketResearchData(
           populationPyramidData: tenYearPyramidData, // Same pyramid data as both use 2023 end data
           yearlyPopulationData: fiveYearlyData
         };
+
+        const stats = await fetchAndFlattenStats(msaInfo.fipsCode);
+        if (completeData.esriData2024 && completeData.esriData2024.employmentByIndustry) {
+          completeData.esriData2024.averageHouseholdIncome = stats.average_household_income;
+          completeData.esriData2024.employmentPopulation = stats.employment_population;
+          completeData.esriData2024.medianHomeValue = stats.median_home_value;
+          completeData.esriData2024.medianHouseholdIncome = stats.median_household_income;
+          completeData.esriData2024.ownerOccupiedUnits = stats.owner_occupied_units;
+          completeData.esriData2024.renterOccupiedUnits = stats.renter_occupied_units;
+          completeData.esriData2024.unemploymentPopulation = stats.unemployment_population;
+          completeData.esriData2024.vacantUnits = stats.vacant_units;
+          completeData.esriData2024.workingAgePopulation = stats.working_age_population;
+          completeData.esriData2024.unemploymentRate = parseFloat(((stats.unemployment_population / stats.working_age_population) * 100).toFixed(1));
+          completeData.esriData2024.employmentByIndustry.industryBasePopulation = stats.industry_base_population;
+          completeData.esriData2024.employmentByIndustry.agricultureForestryFishingHuntingPopulation = stats.agriculture_forestry_fishing_hunting_population;
+          completeData.esriData2024.employmentByIndustry.miningQuarryingOilAndGasExtractionPopulation = stats.mining_quarrying_oil_and_gas_extraction_population;
+          completeData.esriData2024.employmentByIndustry.constructionPopulation = stats.construction_population;
+          completeData.esriData2024.employmentByIndustry.manufacturingPopulation = stats.manufacturing_population;
+          completeData.esriData2024.employmentByIndustry.wholesaleTradePopulation = stats.wholesale_trade_population;
+          completeData.esriData2024.employmentByIndustry.retailTradePopulation = stats.retail_trade_population;
+          completeData.esriData2024.employmentByIndustry.transportationWarehousingPopulation = stats.transportation_warehousing_population;
+          completeData.esriData2024.employmentByIndustry.utilitiesPopulation = stats.utilities_population;
+          completeData.esriData2024.employmentByIndustry.informationPopulation = stats.information_population;
+          completeData.esriData2024.employmentByIndustry.financeInsurancePopulation = stats.finance_insurance_population;
+          completeData.esriData2024.employmentByIndustry.realEstateRentalLeasingPopulation = stats.real_estate_rental_leasing_population;
+          completeData.esriData2024.employmentByIndustry.professionalScientificTechnicalServicesPopulation = stats.professional_scientific_technical_services_population;
+          completeData.esriData2024.employmentByIndustry.managementOfCompaniesEnterprisesPopulation = stats.management_of_companies_enterprises_population;
+          completeData.esriData2024.employmentByIndustry.administrativeSupportWasteManagementServicesPopulation = stats.administrative_support_waste_management_services_population;
+          completeData.esriData2024.employmentByIndustry.educationalServicesPopulation = stats.educational_services_population;
+          completeData.esriData2024.employmentByIndustry.healthCareSocialAssistancePopulation = stats.health_care_social_assistance_population;
+          completeData.esriData2024.employmentByIndustry.artsEntertainmentRecreationPopulation = stats.arts_entertainment_recreation_population;
+          completeData.esriData2024.employmentByIndustry.accommodationFoodServicesPopulation = stats.accommodation_food_services_population;
+          completeData.esriData2024.employmentByIndustry.otherServicesPopulation = stats.other_services_population;
+          completeData.esriData2024.employmentByIndustry.publicAdministrationPopulation = stats.public_administration_population;
+        }
+        setEsriData2024(completeData.esriData2024);
         
         // Store the complete data with both 5 and 10 year datasets in localStorage
         localStorage.setItem(cacheKey, JSON.stringify(completeData));
@@ -193,6 +270,8 @@ export function useMarketResearchData(
           setMarketData(fiveYearCompiledData);
           setPopulationPyramidData(tenYearPyramidData);
         }
+
+        
       } catch (err) {
         console.error('Error fetching market research data:', err);
         setError('Failed to load market research data');
@@ -208,6 +287,7 @@ export function useMarketResearchData(
     marketData,
     yearlyPopulationData,
     populationPyramidData,
+    esriData2024,
     msaName,
     loading,
     error
@@ -218,7 +298,7 @@ export function useMarketResearchData(
 async function fetchMsaInfo(supabase: SupabaseClient, location: string) {
   const { data: msaData, error: msaError } = await supabase
     .from("2023_Catwalk")
-    .select("msa, msa_name")
+    .select("msa, msa_name, fips_code")
     .eq("county_name", location)
     .limit(1);
   
@@ -229,7 +309,8 @@ async function fetchMsaInfo(supabase: SupabaseClient, location: string) {
   
   return {
     msaId: msaData[0].msa,
-    msaName: msaData[0].msa_name
+    msaName: msaData[0].msa_name,
+    fipsCode: msaData[0].fips_code
   };
 }
 
@@ -372,7 +453,118 @@ function createPopulationPyramidData(dataEnd: YearlyPopulationDataSchema) {
     { ageGroup: '80-84', percentage: dataEnd.population_75_to_84_percent / 2 },
     { ageGroup: '85+', percentage: dataEnd.population_85_older_percent },
   ];
+
   
   // Sort from oldest to youngest for proper display
   return pyramidData.reverse();
 } 
+
+interface EsriResponse {
+  results: [{
+    value: {
+      FeatureSet: [{
+        features: [{
+          attributes: {
+            MEDHINC_CY: number;
+            AVGHINC_CY: number;
+            OWNER_CY: number;
+            RENTER_CY: number;
+            VACANT_CY: number;
+            UNEMP_CY: number;
+            EMP_CY: number;
+            AVGVAL_CY: number;
+            WORKAGE_CY: number;
+            INDBASE_CY: number;
+            INDAGRI_CY: number;
+            INDMIN_CY: number;
+            INDCONS_CY: number;
+            INDMANU_CY: number;
+            INDWHTR_CY: number;
+            INDRTTR_CY: number;
+            INDTRAN_CY: number;
+            INDUTIL_CY: number;
+            INDINFO_CY: number;
+            INDFIN_CY: number;
+            INDRE_CY: number;
+            INDTECH_CY: number;
+            INDMGMT_CY: number;
+            INDADMN_CY: number;
+            INDEDUC_CY: number;
+            INDHLTH_CY: number;
+            INDARTS_CY: number;
+            INDFOOD_CY: number;
+            INDOTSV_CY: number;
+            INDPUBL_CY: number;
+          }
+        }]
+      }]
+    }
+  }]
+}
+
+async function fetchEsriData(fipsCode: string) {
+  const apiKey = process.env.NEXT_PUBLIC_ESRI_API_KEY;
+  const baseUrl = 'https://geoenrich.arcgis.com/arcgis/rest/services/World/GeoEnrichmentServer/GeoEnrichment/enrich';
+
+  const url = new URL(baseUrl);
+  url.searchParams.append('f', 'json');
+  url.searchParams.append('token', apiKey || '');
+  url.searchParams.append('studyAreas', JSON.stringify([{"sourceCountry":"US","layer":"US.Counties","ids":[fipsCode]}]));
+  url.searchParams.append('analysisVariables', 'MEDHINC_CY,AVGHINC_CY,OWNER_CY,RENTER_CY,VACANT_CY,UNEMP_CY,EMP_CY,AVGVAL_CY,AVGRENT_CY,INSPOP_CY,WORKAGE_CY,INDBASE_CY,INDAGRI_CY,INDMIN_CY,INDCONS_CY,INDMANU_CY,INDWHTR_CY,INDRTTR_CY,INDTRAN_CY,INDUTIL_CY,INDINFO_CY,INDFIN_CY,INDRE_CY,INDTECH_CY,INDMGMT_CY,INDADMN_CY,INDEDUC_CY,INDHLTH_CY,INDARTS_CY,INDFOOD_CY,INDOTSV_CY,INDPUBL_CY');
+
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+  });
+
+  const data = await response.json();
+  console.log(data);
+  return data;
+}
+
+function flattenGeoenrichmentResponse(data: EsriResponse) {
+  const attributes = data?.results?.[0]?.value?.FeatureSet?.[0]?.features?.[0]?.attributes;
+
+  if (!attributes) {
+    throw new Error('Invalid GeoEnrichment response structure.');
+  }
+
+  return {
+    median_household_income: attributes.MEDHINC_CY ?? null,
+    average_household_income: attributes.AVGHINC_CY ?? null,
+    owner_occupied_units: attributes.OWNER_CY ?? null,
+    renter_occupied_units: attributes.RENTER_CY ?? null,
+    vacant_units: attributes.VACANT_CY ?? null,
+    unemployment_population: attributes.UNEMP_CY ?? null,
+    employment_population: attributes.EMP_CY ?? null,
+    median_home_value: attributes.AVGVAL_CY ?? null,
+    working_age_population: attributes.WORKAGE_CY ?? null,
+    industry_base_population: attributes.INDBASE_CY ?? null,
+    agriculture_forestry_fishing_hunting_population: attributes.INDAGRI_CY ?? null,
+    mining_quarrying_oil_and_gas_extraction_population: attributes.INDMIN_CY ?? null,
+    construction_population: attributes.INDCONS_CY ?? null,
+    manufacturing_population: attributes.INDMANU_CY ?? null,
+    wholesale_trade_population: attributes.INDWHTR_CY ?? null,
+    retail_trade_population: attributes.INDRTTR_CY ?? null,
+    transportation_warehousing_population: attributes.INDTRAN_CY ?? null,
+    utilities_population: attributes.INDUTIL_CY ?? null,
+    information_population: attributes.INDINFO_CY ?? null,
+    finance_insurance_population: attributes.INDFIN_CY ?? null,
+    real_estate_rental_leasing_population: attributes.INDRE_CY ?? null,
+    professional_scientific_technical_services_population: attributes.INDTECH_CY ?? null,
+    management_of_companies_enterprises_population: attributes.INDMGMT_CY ?? null,
+    administrative_support_waste_management_services_population: attributes.INDADMN_CY ?? null,
+    educational_services_population: attributes.INDEDUC_CY ?? null,
+    health_care_social_assistance_population: attributes.INDHLTH_CY ?? null,
+    arts_entertainment_recreation_population: attributes.INDARTS_CY ?? null,
+    accommodation_food_services_population: attributes.INDFOOD_CY ?? null,
+    other_services_population: attributes.INDOTSV_CY ?? null,
+    public_administration_population: attributes.INDPUBL_CY ?? null,
+  };
+}
+
+async function fetchAndFlattenStats(fipsCode: string) {
+  const rawData = await fetchEsriData(fipsCode);
+  const cleanData = flattenGeoenrichmentResponse(rawData);
+  console.log(cleanData);
+  return cleanData;
+}

--- a/frontend/schemas/views/market-research-schema.ts
+++ b/frontend/schemas/views/market-research-schema.ts
@@ -91,6 +91,7 @@ export const MarketResearchSchema = z.object({
   "location": z.string(),
   "msaName": z.string(),
   "msaId": z.number(),
+  "fipsCode": z.string(),
   "fiveYearData": z.object({
     "marketData": z.object({
             "pop_end": z.number(),
@@ -137,7 +138,78 @@ export const MarketResearchSchema = z.object({
     "populationPyramidData": z.array(populationPyramidDataPointSchema),
     "yearlyPopulationData": z.array(yearlyPopulationGraphDataPointSchema),
   }),
+  "esriData2024": z.object({
+    "averageHouseholdIncome": z.number(),
+    "employmentPopulation": z.number(),
+    "medianHomeValue": z.number(),
+    "medianHouseholdIncome": z.number(),
+    "ownerOccupiedUnits": z.number(),
+    "renterOccupiedUnits": z.number(),
+    "unemploymentPopulation": z.number(),
+    "vacantUnits": z.number(),
+    "workingAgePopulation": z.number(),
+    "unemploymentRate": z.number(),
+    "employmentByIndustry": z.object({
+        "industryBasePopulation": z.number(),
+        "agricultureForestryFishingHuntingPopulation": z.number(),
+        "miningQuarryingOilAndGasExtractionPopulation": z.number(),
+        "constructionPopulation": z.number(),
+        "manufacturingPopulation": z.number(),
+        "wholesaleTradePopulation": z.number(),
+        "retailTradePopulation": z.number(),
+        "transportationWarehousingPopulation": z.number(),
+        "utilitiesPopulation": z.number(),
+        "informationPopulation": z.number(),
+        "financeInsurancePopulation": z.number(),
+        "realEstateRentalLeasingPopulation": z.number(),
+        "professionalScientificTechnicalServicesPopulation": z.number(),
+        "managementOfCompaniesEnterprisesPopulation": z.number(),
+        "administrativeSupportWasteManagementServicesPopulation": z.number(),
+        "educationalServicesPopulation": z.number(),
+        "healthCareSocialAssistancePopulation": z.number(),
+        "artsEntertainmentRecreationPopulation": z.number(),
+        "accommodationFoodServicesPopulation": z.number(),
+        "otherServicesPopulation": z.number(),
+        "publicAdministrationPopulation": z.number(),
+    }).nullable()
+  })
 });
+
+export type EsriData2024Schema = {
+    averageHouseholdIncome: number;
+    employmentPopulation: number;
+    medianHomeValue: number;
+    medianHouseholdIncome: number;
+    ownerOccupiedUnits: number;
+    renterOccupiedUnits: number;
+    unemploymentPopulation: number;
+    vacantUnits: number;
+    workingAgePopulation: number;
+    unemploymentRate: number;
+    employmentByIndustry: {
+        industryBasePopulation: number;
+        agricultureForestryFishingHuntingPopulation: number;
+        miningQuarryingOilAndGasExtractionPopulation: number;
+        constructionPopulation: number;
+        manufacturingPopulation: number;
+        wholesaleTradePopulation: number;
+        retailTradePopulation: number;
+        transportationWarehousingPopulation: number;
+        utilitiesPopulation: number;
+        informationPopulation: number;
+        financeInsurancePopulation: number;
+        realEstateRentalLeasingPopulation: number;
+        professionalScientificTechnicalServicesPopulation: number;
+        managementOfCompaniesEnterprisesPopulation: number;
+        administrativeSupportWasteManagementServicesPopulation: number;
+        educationalServicesPopulation: number;
+        healthCareSocialAssistancePopulation: number;
+        artsEntertainmentRecreationPopulation: number;
+        accommodationFoodServicesPopulation: number;
+        otherServicesPopulation: number;
+        publicAdministrationPopulation: number;
+    } | null;
+} | null;
 
 export type MarketResearch = z.infer<typeof MarketResearchSchema>;
 export type MarketResearchDataSchema = z.infer<typeof marketResearchDataSchema>;


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds comprehensive housing metrics and industry employment data visualization to the market research section, leveraging Esri's 2024 dataset.

- Added new `HousingMetrics` component in `/frontend/components/housing-metrics.tsx` to display household financials and home ownership statistics
- Added `IndustryGraph` and `IndustryTable` components for employment data visualization with pie charts and tabular views
- Updated date ranges in `useMarketResearchData.ts` from 2013-2023 to 2014-2023 for 10-year data and 2018-2023 to 2019-2023 for 5-year data
- Added FIPS code and industry-specific employment fields to `market-research-schema.ts`, though there are inconsistencies in nullability between Zod and TypeScript definitions
- Integrated unemployment rate from Esri data into the `PopulationMetrics` component's Workforce section

The changes look solid overall but need attention to type safety and nullability handling across the schema definitions.



<sub>💡 (5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->