### PR TITLE
bug fix

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,7 +9,6 @@ import { NavBar } from "@/components/nav-bar"
 import { FeatureCard } from "@/components/feature-card"
 import { CarouselImage } from "@/components/carousel-image"
 import { useRouter } from "next/navigation"
-import { canFetchAttomData } from "@/lib/attom-data-fetcher"
 import { v4 as uuidv4 } from "uuid"
 
 // Helper to load Google Maps script
@@ -204,13 +203,7 @@ export default function Home() {
       const state = stateComponent?.long_name || stateComponent?.short_name;
       localStorage.setItem("state", state || "");
     }
-
-    const canFetch = await canFetchAttomData(address)
-    if (!canFetch) {
-      localStorage.setItem("isAddressSupported", "false")
-    } else {
-      localStorage.setItem("isAddressSupported", "true")
-    }
+    
     // test attom api call
     router.push("/report")
   }


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Removed address validation function `canFetchAttomData` and consolidated validation logic to use `isAddressInIndiana`, introducing potential issues with duplicate validation checks and inconsistent address handling.

- Removed critical `canFetchAttomData` function import and check from `frontend/app/page.tsx`, weakening address validation
- Duplicate validation logic in both `place_changed` event and `handleSubmit` could lead to inconsistent results
- No fallback validation if Google Places API fails to load or return place data
- Consider consolidating validation into a single reusable function to maintain consistency
- Missing error handling for edge cases where address components are incomplete/invalid

The changes appear to introduce potential bugs and inconsistencies in address validation. Evan, this is a sloppy implementation that could break address validation in production. Please refactor to use a single, robust validation approach.



<!-- /greptile_comment -->